### PR TITLE
Fixed snippet for stateless components

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -120,7 +120,7 @@
       "import PropTypes from \"prop-types\";",
       "",
       "const ${TM_FILENAME_BASE} = props => {",
-      "  render();",
+      "  return(<div />);",
       "};",
       "",
       "${TM_FILENAME_BASE}.propTypes = {};",


### PR DESCRIPTION
Corrected snippet for stateless react component. `render` replace with `return` statement.